### PR TITLE
Make all 'base' variables local

### DIFF
--- a/testing/widget_dailytimer.js
+++ b/testing/widget_dailytimer.js
@@ -71,7 +71,7 @@ var widget_dailytimer = $.extend({}, widget_settimer, {
         ).appendTo(elem);
     },
     init: function () {
-        base = this;
+        var base = this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             base.init_attr($(this));
@@ -108,7 +108,7 @@ var widget_dailytimer = $.extend({}, widget_settimer, {
         });
     },
     update: function (dev,par) {
-        base = this;
+        var base = this;
         var deviceElements;
         if ( dev == '*' )
             deviceElements= this.elements;

--- a/testing/widget_svgplot.js
+++ b/testing/widget_svgplot.js
@@ -5,7 +5,7 @@ if(typeof widget_image == 'undefined') {
 var widget_svgplot = $.extend({}, widget_image, {
     widgetname : 'svgplot',
     init: function () {
-        base=this;
+        var base=this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             readings['+GPLOTFILE']=true;
@@ -23,6 +23,7 @@ var widget_svgplot = $.extend({}, widget_image, {
     },
     update: function (dev,par) {
         var deviceElements= this.elements.filter('div[data-device="'+dev+'"]');
+        var base=this;
 	    deviceElements.each(function(index) {
             var device = $(this).data('device');
             if(device && deviceStates[device]) {

--- a/www/tablet/js/widget_clicksound.js
+++ b/www/tablet/js/widget_clicksound.js
@@ -53,7 +53,7 @@ var widget_clicksound = $.extend({}, widget_widget, {
         elem.data('length',             elem.data('length')         || 200);
     },
     init: function () {
-        base = this;
+        var base = this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             $(this).css("display","none");

--- a/www/tablet/js/widget_iframe.js
+++ b/www/tablet/js/widget_iframe.js
@@ -80,7 +80,7 @@ var widget_iframe = $.extend({}, widget_widget, {
         });
     },
     update: function (dev,par) {
-        base = this;
+        var base = this;
         var deviceElements= this.elements.filter('div[data-device="'+dev+'"]');
         deviceElements.each(function(index) {
             if ( $(this).data('get')==par || par =='*') {   

--- a/www/tablet/js/widget_itunes_artwork.js
+++ b/www/tablet/js/widget_itunes_artwork.js
@@ -127,7 +127,7 @@ var widget_itunes_artwork = $.extend({}, widget_image, {
         });
     },
     update: function (dev,par) {
-        base = this;
+        var base = this;
         var deviceElements = this.elements.filter('div[data-device="'+dev+'"]');
         deviceElements.each(function(index) {
             var img = $(this).find('img');
@@ -162,7 +162,6 @@ var widget_itunes_artwork = $.extend({}, widget_image, {
                     $(this).data('updateinprogress', true);
                     // there's a timing issue with readings updates in MPD
                     var timedUpdate = setTimeout($.proxy(function() {
-                        base = widget_itunes_artwork; // this shouldn't be necessary -> get rid of it
                         var get = $(this).data('get');
                         var done=0;
                         var changed=false;

--- a/www/tablet/js/widget_javascript.js
+++ b/www/tablet/js/widget_javascript.js
@@ -9,14 +9,14 @@ var widget_javascript = $.extend({}, widget_widget, {
         elem.data('get',        elem.data('get')    ||  'STATE');
     },
     init: function () {
-        base = this;
+        var base = this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             base.init_attr($(this));
         });
     },
     update: function (dev,par) {
-        base = this;
+        var base = this;
         var deviceElements= this.elements.filter('div[data-device="'+dev+'"]');
         deviceElements.each(function(index) {
             if ( $(this).data('get')==par){

--- a/www/tablet/js/widget_joinedlabel.js
+++ b/www/tablet/js/widget_joinedlabel.js
@@ -19,7 +19,7 @@ var widget_joinedlabel = $.extend({}, widget_label, {
         return value;
     },
     update: function (dev,par) {
-        base=this;
+        var base=this;
         var deviceElements= this.elements;
         deviceElements.each(function(index) {
             var get = $(this).data('get');

--- a/www/tablet/js/widget_klimatrend.js
+++ b/www/tablet/js/widget_klimatrend.js
@@ -5,7 +5,7 @@ if(typeof widget_widget == 'undefined') {
 var widget_klimatrend = $.extend({}, widget_widget, {
     widgetname : 'klimatrend',
     init: function () {
-        base=this;
+        var base=this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             $(this).data('get', $(this).data('get') || 'statTemperatureTendency'); 

--- a/www/tablet/js/widget_kodinowplaying.js
+++ b/www/tablet/js/widget_kodinowplaying.js
@@ -5,7 +5,7 @@ if(typeof widget_widget == 'undefined') {
 var widget_kodinowplaying = $.extend({}, widget_widget, {
     widgetname:"kodinowplaying",
     init: function () {
-        base=this;
+        var base=this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             if($(this).hasClass('titleonly')){

--- a/www/tablet/js/widget_mpdnowplaying.js
+++ b/www/tablet/js/widget_mpdnowplaying.js
@@ -5,7 +5,7 @@ if(typeof widget_joinedlabel == 'undefined') {
 var widget_mpdnowplaying = $.extend({}, widget_joinedlabel, {
     widgetname:"mpdnowplaying",
     init: function () {
-        base=this;
+        var base=this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             var album   =  typeof $(this).data('album')  != 'undefined' ? $(this).data('album')  : 'album';

--- a/www/tablet/js/widget_reload.js
+++ b/www/tablet/js/widget_reload.js
@@ -11,14 +11,14 @@ var widget_reload = $.extend({}, widget_widget, {
         elem.data('get-off',    elem.data('get-off')    || elem.data('reset-to')     || 0);
     },
     init: function () {
-        base = this;
+        var base = this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             base.init_attr($(this));
         });
     },
     update: function (dev,par) {
-        base = this;
+        var base = this;
         var deviceElements= this.elements.filter('div[data-device="'+dev+'"]');
         deviceElements.each(function(index) {
             if ( $(this).data('get')==par){

--- a/www/tablet/js/widget_settimer.js
+++ b/www/tablet/js/widget_settimer.js
@@ -5,7 +5,7 @@ if(typeof widget_volume == 'undefined') {
 var widget_settimer = $.extend({}, widget_volume, {
     widgetname: 'settimer',
     init: function () {
-        base=this;
+        var base=this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             var device = $(this).data('device');
@@ -141,6 +141,7 @@ var widget_settimer = $.extend({}, widget_volume, {
     },
     update: function (dev,par) {
         var deviceElements= this.elements.filter('div[data-device="'+dev+'"]');
+        var base=this;
         deviceElements.each(function(index) {
             button_off = $(this).find('.widget_settimer_off');
             var button_off_bg = button_off.find('#bg');

--- a/www/tablet/js/widget_wind_direction.js
+++ b/www/tablet/js/widget_wind_direction.js
@@ -8,7 +8,7 @@ if(typeof widget_volume == 'undefined') {
 var widget_wind_direction = $.extend({}, widget_volume, {
     widgetname: 'wind_direction',
     init: function () {
-        base=this;
+        var base=this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             var knob_elem =  jQuery('<input/>', {


### PR DESCRIPTION
Prefix all `base=this;` with a `var`, and add new ones where necessary.

Should fix nesges/Widgets-for-fhem-tablet-ui#3
There was an incomplete workaround for the same problem in www/tablet/js/widget_itunes_artwork.js which I removed, untested.
## Explanation

Looking through the original widget code I found what the `base` was supposed to do: It's a closure that keeps a reference to the widget class/object thingy. This is normally available in `this`, but with jQuery style iterators (like `.each()`) with callbacks the `this` gets replaced with the current element. Due to this each widget method needs its own `var base = this;` (and a central one in `init` doesn't suffice).
