### PR TITLE
Fix interval usage on the countdown widget

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,5 @@
+2016-05-28
+ widget_countdown: use the interval attribute when setting a timer
 2016-02-01
  widget_countdown: setTimeout statt setInterval bei resettimeout
 2016-02-01

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Die Widgets dieser Sammlung sind zur Verwendung in [fhem-tablet-ui](https://gith
 
 * [button] (https://github.com/nesges/Widgets-for-fhem-tablet-ui/wiki/button)
 * [clock] (https://github.com/nesges/Widgets-for-fhem-tablet-ui/wiki/clock)
+* [countdown] (https://github.com/nesges/Widgets-for-fhem-tablet-ui/wiki/countdown)
 * [iframe] (https://github.com/nesges/Widgets-for-fhem-tablet-ui/wiki/iframe)
 * [klimatrend](https://github.com/nesges/Widgets-for-fhem-tablet-ui/wiki/klimatrend)
 * [kodinowplaying](https://github.com/nesges/Widgets-for-fhem-tablet-ui/wiki/kodinowplaying)

--- a/controls_widgets-for-fhem-tablet-ui.txt
+++ b/controls_widgets-for-fhem-tablet-ui.txt
@@ -85,7 +85,7 @@ UPD 2015-04-30_13:43:16 7634 www/tablet/lib/ion.sound/sounds/metal_plate.aac
 UPD 2015-04-30_13:43:16 35092 www/tablet/lib/ion.sound/sounds/door_bell.aac
 UPD 2015-04-30_13:43:16 16366 www/tablet/lib/ion.sound/sounds/water_droplet_2.mp3
 UPD 2015-04-30_13:43:16 25716 www/tablet/lib/ion.sound/sounds/metal_plate_2.aac
-UPD 2016-02-01_22:11:15 3980 www/tablet/js/widget_countdown.js
+UPD 2016-05-28_15:48:50 4020 www/tablet/js/widget_countdown.js
 UPD 2015-06-17_09:47:11 8588 www/tablet/js/widget_kodinowplaying.js
 UPD 2016-02-01_11:54:59 2836 www/tablet/js/widget_button.js
 UPD 2015-06-17_18:20:36 5954 www/tablet/js/widget_clock.js

--- a/www/tablet/js/widget_countdown.js
+++ b/www/tablet/js/widget_countdown.js
@@ -90,7 +90,7 @@ var widget_countdown = $.extend({}, widget_widget, {
             f.elem = $(this);
             f.value = $(this).getReading('get').val;
             
-            $(this).data('__timer', setInterval(f, 1000));
+            $(this).data('__timer', setInterval(f, $(this).data('interval')));
         });
     },
     update: function (dev,par) {
@@ -104,7 +104,7 @@ var widget_countdown = $.extend({}, widget_widget, {
             f.value = $(this).getReading('get').val;
 
             clearInterval($(this).data('__timer'));
-            $(this).data('__timer', setInterval(f, 1000));
+            $(this).data('__timer', setInterval(f, $(this).data('interval')));
         });
     }
 });


### PR DESCRIPTION
The wiki entry listed an attribute called _interval_ for the countdown widget but it wasn't used in the code. This PR should fix that.
